### PR TITLE
update mill api structure

### DIFF
--- a/custom_components/mill/manifest.json
+++ b/custom_components/mill/manifest.json
@@ -8,7 +8,7 @@
   "issue_tracker": "https://github.com/theOrakle/mill/issues",
   "loggers": ["custom_components.mill"],
   "requirements": [],
-  "version": "1.0.8",
+  "version": "1.0.9",
   "dependencies": [],
   "codeowners": ["@theOrakle"]
 }


### PR DESCRIPTION
First off, thanks a stack for your amazing work on this integration, its existence was one of the reasons I decided to get a Mill.

I was unable to get the integration working with my mill. After inspecting the logs I found that the API was returning an empty `deviceIds` attribute even though my app has a mill setup in it and was working fine. I then setup burp and inspected the api calls the app was making. 

I've updated it to match what the app is doing and the integration now works for me. 

